### PR TITLE
ANRs implementado con viewModelScope.launch(Dispatchers.IO)

### DIFF
--- a/app/src/main/java/com/example/vinilosmisw4203_2024/views/ArtistListScreen.kt
+++ b/app/src/main/java/com/example/vinilosmisw4203_2024/views/ArtistListScreen.kt
@@ -34,7 +34,7 @@ fun ArtistListScreen(viewModel: ArtistViewModel) {
 
     LaunchedEffect(Unit) {
         try {
-            viewModel.fetchArtist()
+            viewModel.fetchArtists()
             loading.value = false
         } catch (e: Exception) {
             error.value = e.message ?: "Unknown error"

--- a/app/src/main/java/com/example/vinilosmisw4203_2024/viewsModels/AlbumViewModel.kt
+++ b/app/src/main/java/com/example/vinilosmisw4203_2024/viewsModels/AlbumViewModel.kt
@@ -7,21 +7,31 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.vinilosmisw4203_2024.models.Album
 import com.example.vinilosmisw4203_2024.repositories.AlbumRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class AlbumViewModel : ViewModel() {
-    private val repository = AlbumRepository()  // Correct the spelling mistake here
+    private val repository = AlbumRepository()
     private val _albums = MutableLiveData<List<Album>>()
-    val albums: LiveData<List<Album>> = _albums  // Changed from 'artists' to 'albums'
+    val albums: LiveData<List<Album>> = _albums
+
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+
+    private val _error = MutableLiveData<String>()
+    val error: LiveData<String> = _error
 
     fun fetchAlbums() {
-        viewModelScope.launch {
+        _isLoading.value = true// OPERACIONES DE RED NO VAN AL HILO PRINCIPAL
+        viewModelScope.launch(Dispatchers.IO) {// IMPLEMANTACION DE ANRs UTILIZANDO VIEWMODELSCOPE.LAUNCH(DISPATCHERS.IO)
             try {
-                val listAlbums = repository.getAlbums()  // Correct the method call to match the correct spelling of the repository instance
+                val listAlbums = repository.getAlbums()
                 _albums.postValue(listAlbums)
+                _isLoading.postValue(false)
             } catch (e: Exception) {
                 Log.d("AlbumViewModel", "fetch Albums exception: ${e.message}")
-                _albums.postValue(emptyList())  // Optionally handle errors by posting an empty list
+                _error.postValue(e.message ?: "An unknown error occurred")
+                _isLoading.postValue(false)
             }
         }
     }

--- a/app/src/main/java/com/example/vinilosmisw4203_2024/viewsModels/ArtistViewModel.kt
+++ b/app/src/main/java/com/example/vinilosmisw4203_2024/viewsModels/ArtistViewModel.kt
@@ -1,30 +1,30 @@
 package com.example.vinilosmisw4203_2024.viewsModels
+
 import android.util.Log
-import androidx.lifecycle.ViewModel
-import com.example.vinilosmisw4203_2024.models.Artist
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.vinilosmisw4203_2024.models.Artist
 import com.example.vinilosmisw4203_2024.repositories.ArtistRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class ArtistViewModel : ViewModel() {
-
-    private val respository = ArtistRepository()
+    private val repository = ArtistRepository()
     private val _artists = MutableLiveData<List<Artist>>()
     val artists: LiveData<List<Artist>> = _artists
 
-    fun fetchArtist() {
-        viewModelScope.launch {
+    fun fetchArtists() {
+        _artists.value = listOf() // Pre-clear the current artist list
+        viewModelScope.launch(Dispatchers.IO) { // IMPLEMANTACION DE ANRs UTILIZANDO VIEWMODELSCOPE.LAUNCH(DISPATCHERS.IO)
             try {
-                val listArtist = respository.getArtists()
-                _artists.value = listArtist
-            }catch (e: Exception){
-                Log.d("Repo", "fetch Artist exception ${e.message}")
+                val listArtists = repository.getArtists()
+                _artists.postValue(listArtists)
+            } catch (e: Exception) {
+                Log.d("ArtistViewModel", "fetch Artists exception: ${e.message}")
+                _artists.postValue(emptyList()) // Manejo de errores postando una lista vacía
             }
         }
     }
 }
-
-
-

--- a/app/src/main/java/com/example/vinilosmisw4203_2024/viewsModels/CollectorViewModel.kt
+++ b/app/src/main/java/com/example/vinilosmisw4203_2024/viewsModels/CollectorViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.vinilosmisw4203_2024.models.Collector
 import com.example.vinilosmisw4203_2024.repositories.CollectorRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class CollectorViewModel : ViewModel() {
@@ -15,13 +16,14 @@ class CollectorViewModel : ViewModel() {
     val collectors: LiveData<List<Collector>> = _collectors
 
     fun fetchCollectors() {
-        viewModelScope.launch {
+        _collectors.value = listOf() // Pre-clear the current collector list
+        viewModelScope.launch(Dispatchers.IO) { // IMPLEMANTACION DE ANRs UTILIZANDO VIEWMODELSCOPE.LAUNCH(DISPATCHERS.IO)
             try {
                 val listCollectors = repository.getCollectors()
                 _collectors.postValue(listCollectors)
             } catch (e: Exception) {
                 Log.d("CollectorViewModel", "fetch Collectors exception: ${e.message}")
-                _collectors.postValue(emptyList())  // Optionally handle errors by posting an empty list
+                _collectors.postValue(emptyList()) // Manejo de errores postando una lista vacía
             }
         }
     }


### PR DESCRIPTION
se evita el bloqueo de la rama principal cuando se hace fetch de los listados 